### PR TITLE
Fix PTU apply for applications with default permissions

### DIFF
--- a/src/components/policy/policy_regular/include/policy/policy_helper.h
+++ b/src/components/policy/policy_regular/include/policy/policy_helper.h
@@ -114,7 +114,8 @@ struct CheckAppPolicy {
       const std::vector<FunctionalGroupPermission>& revoked_groups) const;
   bool IsKnownAppication(const std::string& application_id) const;
   void NotifySystem(const AppPoliciesValueType& app_policy) const;
-  void SendPermissionsToApp(const AppPoliciesValueType& app_policy) const;
+  void SendPermissionsToApp(const std::string& app_id,
+                            const policy_table::Strings& groups) const;
   bool IsAppRevoked(const AppPoliciesValueType& app_policy) const;
   bool NicknamesMatch(const AppPoliciesValueType& app_policy) const;
   /**


### PR DESCRIPTION
There was a problem in PROPRIETARY flow that SDL does not update permissions for applications with default policies after PTU if application functional group was updated indirectly (through updating of `"default" `section).

Also SDL does not send `OnPermissionChange` notification in described above case.

This fix adds extra check if `"default"` functional group was updated and there are registered applications with
default policies group and also updates them. Similar check was added for sending `OnPermissionChange` notification.

This fix completes fix from https://github.com/smartdevicelink/sdl_core/pull/1779
Fixes https://github.com/SmartDeviceLink/sdl_core/issues/1772